### PR TITLE
Fix for -Wmissing-braces

### DIFF
--- a/OneLoneCoder/PGE App.xctemplate/olcPixelGameEngine.h
+++ b/OneLoneCoder/PGE App.xctemplate/olcPixelGameEngine.h
@@ -857,12 +857,12 @@ namespace olc
     // State of keyboard
     bool    pKeyNewState[256] = { 0 };
     bool    pKeyOldState[256] = { 0 };
-    HWButton  pKeyboardState[256] = { 0 };
+    HWButton  pKeyboardState[256] = {{ 0 }};
 
     // State of mouse
     bool    pMouseNewState[nMouseButtons] = { 0 };
     bool    pMouseOldState[nMouseButtons] = { 0 };
-    HWButton  pMouseState[nMouseButtons] = { 0 };
+    HWButton  pMouseState[nMouseButtons] = {{ 0 }};
 
     // The main engine thread
     void    EngineThread();


### PR DESCRIPTION
- Use initializer list {{ ... }} instead of single braces.
- This resolves the warning:
    - warning: suggest braces around initialization of subobject [-Wmissing-braces]