### PR TITLE
Update olcPixelGameEngine.h

### DIFF
--- a/OneLoneCoder/PGE App.xctemplate/olcPixelGameEngine.h
+++ b/OneLoneCoder/PGE App.xctemplate/olcPixelGameEngine.h
@@ -345,6 +345,7 @@ int main()
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <assert.h>
 #pragma endregion
 
 #define PGE_VER 215


### PR DESCRIPTION
Added an #include for assert.h to fix compilation error 

./olcPixelGameEngine.h:4856:13: error: use of undeclared identifier 'assert'
            assert(resultAddMethod);
            ^

which appeared after updating to macOS 10.4 Sonoma.