### PR TITLE
Update olcPixelGameEngine.h

### DIFF
--- a/OneLoneCoder/PGE App.xctemplate/olcPixelGameEngine.h
+++ b/OneLoneCoder/PGE App.xctemplate/olcPixelGameEngine.h
@@ -3288,7 +3288,7 @@ namespace olc
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         }
 
-        void SetDecalMode(const olc::DecalMode& mode)
+        void SetDecalMode(const olc::DecalMode& mode) override
         {
             if (mode != nDecalMode)
             {


### PR DESCRIPTION
Silences warning:

warning: 'SetDecalMode' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        void SetDecalMode(const olc::DecalMode& mode)
             ^
/Users/benjaminantonellis/Desktop/olc_mac/./olcPixelGameEngine.h:819:28: note: overridden virtual function is here
        virtual void       SetDecalMode(const olc::DecalMode& mode) = 0;